### PR TITLE
Fix redirect link in documentation

### DIFF
--- a/pages/docs.mdx
+++ b/pages/docs.mdx
@@ -300,7 +300,7 @@ navigation:
     path: /about/
 ```
 
-### Edit on GitHub
+## Edit on GitHub
 
 If your website is open source you could set your repository URL, Contentz will then build the website and it automatically add the text `Edit on GitHub` in the footer with the GitHub icon.
 

--- a/pages/docs.mdx
+++ b/pages/docs.mdx
@@ -256,7 +256,7 @@ Contentz has default support to Incremental Build, what does this mean? If you r
 
 If for some reason you want to disable this feature you will need to set `incremental: false` in your `config.yml`.
 
-## Social Networks & Email Address
+## Social Networks and Email Address
 
 In case you want to link your social networks from the homepage it's possible to add them to your `config.yml` under the key `social`.
 


### PR DESCRIPTION
When you build `contentz` page and generate `pages/docs.mdx`, in the nav internal does not recognize `&` in this `Social Networks & Email ` and builds it `social-networks--email `. The solution, change `&` to `and`, now redirect correctly.

Close #1 